### PR TITLE
Update license to Apache 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - dswah
+    - jtilly

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -34,8 +34,8 @@ test:
 
 about:
   home: https://github.com/dswah/pyGAM
-  license: GPL-3.0-or-later
-  license_family: GPL
+  license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: Generalized Additive Models in Python
   description: |


### PR DESCRIPTION
pygam changed its license to Apache in this commit https://github.com/dswah/pyGAM/commit/a8462478f8b8f7aac5bcf71d7cbff94c09a8fc38 (which was released as part of 0.9.0).

That's also the license listed for the pypi build: https://pypi.org/project/pygam/

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
